### PR TITLE
storage: guard client.Close()

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -253,5 +253,8 @@ func (g *gcsStore) DeleteLock(ctx context.Context, lockID objects.MAC) error {
 }
 
 func (g *gcsStore) Close(ctx context.Context) error {
-	return g.client.Close()
+	if g.client != nil {
+		return g.client.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
if other errors happens, g.client might still be nil, and then we crash inside the google storage library.  Incidentally, it's what the importer and exporter are already doing.

reported by @Balakao in the Plakar issue
https://github.com/PlakarKorp/plakar/issues/1769